### PR TITLE
feat: 404 Not found 핸들링

### DIFF
--- a/src/api/axiosConfig.js
+++ b/src/api/axiosConfig.js
@@ -1,8 +1,5 @@
 import axios from 'axios';
-import { createBrowserHistory } from 'history';
 
-const history = createBrowserHistory();
-// axios.defaults.withCredentials = true;
 const axiosInstance = axios.create({
   baseURL: 'https://api.jdnclib.com',
   headers: { Authorization: '' },
@@ -41,7 +38,6 @@ axiosInstance.interceptors.response.use(
     return response;
   },
   (error) => {
-    // handleHTTPError(object);
     if (error.response.status === 500) {
     }
     if (error.response.status === 403) {

--- a/src/components/AdminLayout/AdminLayout.jsx
+++ b/src/components/AdminLayout/AdminLayout.jsx
@@ -30,7 +30,6 @@ const AdminLayout = ({ children }) => {
     async function getUserInfo() {
       try {
         const response = await fetchGETUserInfo();
-
         dispatch(updateUserInfo(response.data));
         setUsername(response.data.name);
         if(response.data.role === 'ROLE_USER') {

--- a/src/components/AdminThead/AdminThead.jsx
+++ b/src/components/AdminThead/AdminThead.jsx
@@ -19,31 +19,3 @@ const AdminThead = ({ rowTitleData , children }) => {
 }
 
 export default AdminThead;
-
-
-{/* <table>
-      <thead>
-        <tr>
-          <th>상단 타이틀</th>
-          <th>연번</th>
-          <th>기수</th>
-          <th>인재번호</th>
-          <th>이름</th>
-          <th>대출 상황</th>
-          <th>관리</th>
-          <th>구분</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-          <td>값</td>
-        </tr>
-      </tbody>
-    </table> */}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,6 +22,7 @@ import BookDetailPage from '../pages/BookDetailPage/BookDetailPage';
 import BookKeeperMainPage from '../pages/BookKeeperMainPage/BookKeeperMainPage';
 import BookKeeperBorrowedListPage from '../pages/BookKeeperBorrowedListPage/BookKeeperBorrowedListPage';
 import BookKeeperMonthlyPage from '../pages/BookKeeperMonthlyPage/BookKeeperMonthlyPage';
+import NotFound from '../pages/NotFound/NotFound';
 
 const App = () => {
   return (
@@ -80,6 +81,7 @@ const App = () => {
             path={navigateUrl.adminBorrowedList}
             element={<AdminLayout children={<AdminBorrowedListPage />} />}
           /> */}
+          <Route path='*' element={<NotFound />} />
         </Routes>
       </ThemeProvider>
     </BrowserRouter>

--- a/src/components/CreateQR/CreateQR.jsx
+++ b/src/components/CreateQR/CreateQR.jsx
@@ -27,6 +27,7 @@ const CreateQR = () => {
       setBookNumberCanvasImage(bookNumberCanvas.current.toDataURL('image/jpg'));
     }
   }
+  
   const handleFileName = (event) => {
     const value = event.target.value;
     setFileName(value);

--- a/src/components/Layout/Layout.jsx
+++ b/src/components/Layout/Layout.jsx
@@ -26,6 +26,7 @@ const Layout = ({ children }) => {
     async function getUserInfo() {
       try {
         const response = await fetchGETUserInfo();
+        console.log(response.data);
         setIsLogin(true);
         dispatch(updateUserInfo(response.data));
       } catch (error) {

--- a/src/components/PageNationButton/PageNationButton.jsx
+++ b/src/components/PageNationButton/PageNationButton.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Style from './PageNationButton.style';
 
 const PageNationButton = ({ totalPage, currentPage, setCurrentPage }) => {
-  const [currentButtonPage, setCurrentButtonPage] = useState(1);
+  const [ currentButtonPage, setCurrentButtonPage ] = useState(1);
 
   const changePage = (page) => {
     setCurrentPage(page);

--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import Style from './NotFound.style';
+import { navigateUrl } from '../../constant/navigateUrl';
+import logo from '../../assets/images/logo.png';
+import { fetchGETUserInfo } from '../../api/user/userInfo';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
+const NotFound = () => {
+  const [ userRole, setUserRole ] = useState(null);
+  const navigate = useNavigate();
+
+  async function getUserInfo() {
+    try {
+      const { data: { role } } = await fetchGETUserInfo();
+      setUserRole(role);
+    } catch (error) {
+      alert('로그인이 필요합니다.');
+      navigate(navigateUrl.login);
+    }
+  }
+
+  useEffect(() => {
+    getUserInfo();
+  }, []);
+
+  return (
+    !userRole ? 
+    <Style.Container>
+      <img src={logo} alt="더큰내일도서관 로고" />
+    </Style.Container>
+    :
+    <Style.Container>
+      <img src={logo} alt="더큰내일도서관 로고" />
+      <div>
+        <strong>
+          <Style.AnimatedText>
+            <span>4</span>
+            <span>0</span>
+            <span>4</span>
+          </Style.AnimatedText>
+        </strong>
+        <span>Not Found</span>
+      </div>
+      <p>페이지를 찾을 수 없습니다.</p>
+      <Style.HomeLinkContainer>
+        {
+          userRole === 'ROLE_ADMIN' ?
+          <Link to={navigateUrl.adminBookList}>홈으로</Link>
+          :
+          <Link to={navigateUrl.main}>홈으로</Link>
+        }
+      </Style.HomeLinkContainer>
+    </Style.Container>
+  )
+}
+
+export default NotFound;

--- a/src/pages/NotFound/NotFound.style.js
+++ b/src/pages/NotFound/NotFound.style.js
@@ -1,0 +1,73 @@
+import styled from "styled-components";
+import { keyframes } from "styled-components";
+
+const NotfoundAnimation = keyframes`
+  0% {
+    transform: translateY(0px);
+  }
+  15% {
+    transform: translateY(-10px);
+  }
+  30% {
+    transform: translateY(0px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
+`;
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
+  height: 100vh;
+  gap: 20px;
+
+  & div {
+    display: flex;
+    flex-direction: row;
+    align-items: last baseline;
+    justify-content: space-between;
+    gap: 10px;
+  }
+`;
+
+const HomeLinkContainer = styled.div`
+  & a {
+    width: 100px;
+    height: 40px;
+    border-radius: 10px;
+    background-color: #4AA7DE;
+    color: white;
+    line-height: 40px;
+    text-align: center;
+  }
+  & a:hover {
+    background-color: #548FDB;
+  }
+`;
+
+const AnimatedText = styled.strong`
+  display: flex;
+  flex-direction: row;
+  align-items: last baseline;
+  color: #4AA7DE;
+  font-size: 40px;
+  font-weight: bold;
+
+  & span:nth-child(1) {
+    animation: ${NotfoundAnimation} 2s ease-in-out infinite;
+  }
+  & span:nth-child(2) {
+    animation: ${NotfoundAnimation} 2s ease-in-out 0.2s infinite;
+  }
+  & span:nth-child(3) {
+    animation: ${NotfoundAnimation} 2s ease-in-out 0.4s infinite;
+  }
+`;
+export default { 
+  Container,
+  HomeLinkContainer,
+  AnimatedText,
+};


### PR DESCRIPTION
### feat: 404 Not found 핸들링


### 내용
1. 404 페이지 제작

2. 유저정보 API 호출
 - useState 기본값 null로 설정 null일 경우 일반 대기 페이지(로고만 띄워진) 렌더링
 - 호출 이후 useState에 role 추가
 - useState가 null이 아닐 경우 404 페이지 렌더링

3. 권한별 페이지 링크
 - 토큰이 정상이 아닐 경우 '로그인이 필요합니다.' 알림창 띄우고 로그인 페이지 리디렉션
 - user role이 admin일 경우 '홈으로' 가기 버튼의 링크가 관리자 페이지 메인으로 설정
 - user role이 일반유저, 도서지기일 경우 '홈으로' 가기 버튼의 링크가 메인 페이지로 설정